### PR TITLE
Add partner to check email

### DIFF
--- a/wallboxapi.js
+++ b/wallboxapi.js
@@ -23,6 +23,7 @@ class wallboxAPI {
 				headers: {
 					'Content-Type': 'application/json',
 					'User-Agent': `${PluginName}/${PluginVersion}`,
+					'Partner': 'wallbox',
 					'Accept-Encoding': 'gzip,deflate,compress'
 				},
 				responseType: 'json'


### PR DESCRIPTION
As part of the Wallbox backend team, we will soon make this header mandatory in this endpoint, which would break this integration.

The "wallbox" value allows the endpoint to search users for the MyWallbox app.